### PR TITLE
README.md fixed service HOME mention to comply to systemd syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ Description=BLE rssi autolock
 
 [Service]
 ExecStart=/usr/bin/python3 /usr/local/bin/ble_rssi_lock.py
-WorkingDirectory=$HOME
-Environment=CONFIG_PATH=.config/systemd/user/ble_rssi_lock/config.ini
+WorkingDirectory=%h
+Environment=CONFIG_PATH=%h/.config/systemd/user/ble_rssi_lock/config.ini
 StandardOutput=inherit
 StandardError=inherit
 Restart=always

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Description=BLE rssi autolock
 [Service]
 ExecStart=/usr/bin/python3 /usr/local/bin/ble_rssi_lock.py
 WorkingDirectory=%h
-Environment=CONFIG_PATH=%h/.config/systemd/user/ble_rssi_lock/config.ini
+Environment=CONFIG_PATH=.config/systemd/user/ble_rssi_lock/config.ini
 StandardOutput=inherit
 StandardError=inherit
 Restart=always


### PR DESCRIPTION
$HOME isn't interpreted, should use %h instead